### PR TITLE
https://docs.symbl.ai/docs/python-sdk/streaming-api/

### DIFF
--- a/python-sdk/overview.md
+++ b/python-sdk/overview.md
@@ -118,6 +118,7 @@ print(conversation_object.get_messages()) # Returns the transcript of the conver
 ## Supported APIs
 
 In this Python SDK release, you can utilize the following Symbl APIs:  
+- [Streaming API (in Real-time)](/docs/python-sdk/streaming-api/)
 - [Telephony API (in Real-time)](/docs/python-sdk/python-sdk-telephony-api)
 - [Async Text API](/docs/python-sdk/async-api)
 - [Async Audio (File) API](/docs/python-sdk/async-audio)  


### PR DESCRIPTION
### PR Details
**Description of the change**: 
Symbl.ai DevRel added a link to Python's convenience methods for streaming: https://docs.symbl.ai/docs/python-sdk/streaming-api/
**Reason for the change**:
The link was missing. 
**Link to original source**:
See above. 

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #